### PR TITLE
wip: fix leaks and use after frees

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -219,7 +219,7 @@ src_iwd_SOURCES = src/main.c linux/nl80211.h src/iwd.h src/missing.h \
 					src/device.c \
 					src/station.h src/station.c \
 					src/ie.h src/ie.c \
-					src/dbus.h src/dbus.c \
+					src/dbus.h src/dbus.c src/dbus-stub.c \
 					src/mpdu.h src/mpdu.c \
 					src/eapol.h src/eapol.c \
 					src/eapolutil.h src/eapolutil.c \

--- a/src/adhoc.c
+++ b/src/adhoc.c
@@ -752,7 +752,6 @@ static void adhoc_netdev_watch(struct netdev *netdev,
 {
 	switch (event) {
 	case NETDEV_WATCH_EVENT_UP:
-#ifdef HAVE_DBUS
 	case NETDEV_WATCH_EVENT_NEW:
 		if (netdev_get_iftype(netdev) == NETDEV_IFTYPE_ADHOC &&
 				netdev_get_is_up(netdev))
@@ -762,7 +761,6 @@ static void adhoc_netdev_watch(struct netdev *netdev,
 	case NETDEV_WATCH_EVENT_DEL:
 		adhoc_remove_interface(netdev);
 		break;
-#endif
 	default:
 		break;
 	}
@@ -771,10 +769,8 @@ static void adhoc_netdev_watch(struct netdev *netdev,
 static int adhoc_init(void)
 {
 	netdev_watch = netdev_watch_add(adhoc_netdev_watch, NULL, NULL);
-#ifdef HAVE_DBUS
 	l_dbus_register_interface(dbus_get_bus(), IWD_ADHOC_INTERFACE,
 			adhoc_setup_interface, adhoc_destroy_interface, false);
-#endif
 
 	return 0;
 }
@@ -782,9 +778,7 @@ static int adhoc_init(void)
 static void adhoc_exit(void)
 {
 	netdev_watch_remove(netdev_watch);
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_ADHOC_INTERFACE);
-#endif
 }
 
 IWD_MODULE(adhoc, adhoc_init, adhoc_exit)

--- a/src/ap.c
+++ b/src/ap.c
@@ -4772,7 +4772,6 @@ static void ap_netdev_watch(struct netdev *netdev,
 {
 	switch (event) {
 	case NETDEV_WATCH_EVENT_UP:
-#ifdef HAVE_DBUS
 	case NETDEV_WATCH_EVENT_NEW:
 		if (netdev_get_iftype(netdev) == NETDEV_IFTYPE_AP &&
 				netdev_get_is_up(netdev))
@@ -4782,7 +4781,6 @@ static void ap_netdev_watch(struct netdev *netdev,
 	case NETDEV_WATCH_EVENT_DEL:
 		ap_remove_interface(netdev);
 		break;
-#endif
 	default:
 		break;
 	}
@@ -4794,13 +4792,11 @@ static int ap_init(void)
 
 	netdev_watch = netdev_watch_add(ap_netdev_watch, NULL, NULL);
 
-#ifdef HAVE_DBUS
 	l_dbus_register_interface(dbus_get_bus(), IWD_AP_INTERFACE,
 			ap_setup_interface, ap_destroy_interface, false);
 	l_dbus_register_interface(dbus_get_bus(), IWD_AP_DIAGNOSTIC_INTERFACE,
 			ap_setup_diagnostic_interface,
 			ap_diagnostic_interface_destroy, false);
-#endif
 
 	/*
 	 * Enable network configuration and DHCP only if
@@ -4831,9 +4827,7 @@ static int ap_init(void)
 static void ap_exit(void)
 {
 	netdev_watch_remove(netdev_watch);
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_AP_INTERFACE);
-#endif
 
 	l_strv_free(global_addr4_strs);
 }

--- a/src/dbus-stub.c
+++ b/src/dbus-stub.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include "ell/ell.h"
+
+#define INTERFACES_LEN 256
+
+struct interface {
+  char *interface;
+  struct {
+    char *object;
+    void *user_data;
+  } objects[256];
+  size_t objects_len;
+  l_dbus_interface_setup_func_t setup_func;
+  l_dbus_destroy_func_t destroy;
+};
+
+static struct interface *get_interfaces(size_t **modify_len) {
+  static size_t len = 0;
+  static struct interface interfaces[INTERFACES_LEN] = {0};
+
+  *modify_len = &len;
+  return interfaces;
+}
+
+bool fake_dbus_register_interface(const char *interface,
+                                  l_dbus_interface_setup_func_t setup_func,
+                                  l_dbus_destroy_func_t destroy) {
+  size_t *len;
+  struct interface *interfaces = get_interfaces(&len);
+
+  if (*len < INTERFACES_LEN) {
+    interfaces[(*len)++] = (struct interface){.interface = l_strdup(interface),
+                                              .setup_func = setup_func,
+                                              .destroy = destroy};
+
+    l_info("Registered interface '%s'", interface);
+
+    return true;
+  }
+
+  assert(false);
+  return false;
+}
+
+bool fake_dbus_unregister_interface(const char *interface) { return true; }
+
+bool fake_dbus_object_add_interface(const char *object, const char *interface,
+                                    void *user_data) {
+  size_t *len;
+  struct interface *interfaces = get_interfaces(&len);
+
+  for (size_t i = 0; i < *len; i++) {
+    struct interface *iface = &interfaces[i];
+
+    if (!strcmp(interface, iface->interface)) {
+      iface->objects[iface->objects_len].object = l_strdup(object);
+      iface->objects[iface->objects_len].user_data = user_data;
+
+      iface->objects_len++;
+
+      iface->setup_func(NULL);
+
+      l_info("Added object '%s' for interface '%s'", object, interface);
+
+      return true;
+    }
+  }
+
+  assert(false);
+  return false;
+}
+
+bool fake_dbus_object_remove_interface(const char *object,
+                                       const char *interface) {
+  size_t *len;
+  struct interface *interfaces = get_interfaces(&len);
+
+  for (size_t i = 0; i < *len; i++) {
+    struct interface *iface = &interfaces[i];
+
+    if (!strcmp(interface, iface->interface)) {
+      for (size_t j = 0; j < iface->objects_len; j++) {
+        if (!strcmp(object, iface->objects[j].object)) {
+          iface->destroy(iface->objects[j].user_data);
+
+          l_info("Removed object '%s' for interface '%s'", object, interface);
+
+          return true;
+        }
+      }
+
+      assert(false);
+      break;
+    }
+  }
+
+  assert(false);
+  return false;
+}

--- a/src/dbus-stub.c
+++ b/src/dbus-stub.c
@@ -88,6 +88,7 @@ bool fake_dbus_object_remove_interface(const char *object,
       for (size_t j = 0; j < iface->objects_len; j++) {
         if (!strcmp(object, iface->objects[j].object)) {
           iface->destroy(iface->objects[j].user_data);
+          iface->objects[j].object[0] = '\0';
 
           return true;
         }

--- a/src/dbus-stub.c
+++ b/src/dbus-stub.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include "ell/ell.h"
+#include "ell/dbus.h"
 
 #define INTERFACES_LEN 256
 

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -30,9 +30,9 @@
 
 #include <ell/ell.h>
 
+#include "src/dbus.h"
 #include "src/agent.h"
 #include "src/iwd.h"
-#include "src/dbus.h"
 
 static struct l_dbus *g_dbus = NULL;
 

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -107,4 +107,9 @@ bool fake_dbus_object_remove_interface(const char *object, const char *interface
 #define l_dbus_interface_signal(...) (false)
 #define l_dbus_interface_property(...) (false)
 #define l_dbus_property_changed(...) (false)
+
+#undef L_DBUS_INTERFACE_DBUS
+#undef L_DBUS_INTERFACE_INTROSPECTABLE
+#undef L_DBUS_INTERFACE_PROPERTIES
+#undef L_DBUS_INTERFACE_OBJECT_MANAGER
 #endif

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -19,7 +19,8 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-
+#ifndef IWD_DBUS_H
+#define IWD_DBUS_H
 #include <stdbool.h>
 
 #define IWD_SERVICE "net.connman.iwd"
@@ -86,3 +87,25 @@ struct l_dbus_message *dbus_error_from_errno(int err,
 bool dbus_init(struct l_dbus *dbus);
 void dbus_exit(void);
 void dbus_shutdown(void);
+
+#ifndef HAVE_DBUS
+bool fake_dbus_register_interface(const char *interface,
+                                  l_dbus_interface_setup_func_t setup_func,
+                                  l_dbus_destroy_func_t destroy);
+bool fake_dbus_unregister_interface(const char *interface);
+bool fake_dbus_object_add_interface(const char *object, const char *interface, void *user_data);
+bool fake_dbus_object_remove_interface(const char *object, const char *interface);
+
+#define l_dbus_register_interface(dbus, interface, setup_func, destroy, handle_old_style_properties) \
+    fake_dbus_register_interface(interface, setup_func, destroy)
+#define l_dbus_unregister_interface(dbus, interface) fake_dbus_unregister_interface(interface)
+#define l_dbus_object_add_interface(dbus, object, interface, user_data) fake_dbus_object_add_interface(object, interface, user_data)
+#define l_dbus_object_remove_interface(dbus, object, interface) fake_dbus_object_remove_interface(object, interface)
+
+/* Stub dbus-service.h */
+#define l_dbus_interface_method(...) (false)
+#define l_dbus_interface_signal(...) (false)
+#define l_dbus_interface_property(...) (false)
+#define l_dbus_property_changed(...) (false)
+#endif
+#endif

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -19,9 +19,9 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
-#ifndef IWD_DBUS_H
-#define IWD_DBUS_H
 #include <stdbool.h>
+#include "ell/dbus.h"
+#include "ell/dbus-service.h"
 
 #define IWD_SERVICE "net.connman.iwd"
 
@@ -107,5 +107,4 @@ bool fake_dbus_object_remove_interface(const char *object, const char *interface
 #define l_dbus_interface_signal(...) (false)
 #define l_dbus_interface_property(...) (false)
 #define l_dbus_property_changed(...) (false)
-#endif
 #endif

--- a/src/device.c
+++ b/src/device.c
@@ -340,20 +340,17 @@ static void device_netdev_notify(struct netdev *netdev,
 					enum netdev_watch_event event,
 					void *user_data)
 {
-#ifdef HAVE_DBUS
 	struct device *device;
 	struct l_dbus *dbus = dbus_get_bus();
 	const char *path = netdev_get_path(netdev);
 
+#ifdef HAVE_DBUS
 	device = l_dbus_object_get_data(dbus, path, IWD_DEVICE_INTERFACE);
 
 	if (!device && event != NETDEV_WATCH_EVENT_NEW)
 		return;
 #else
-    // TODO
-    struct device *device = NULL;
-    struct l_dbus *dbus = dbus_get_bus();
-    const char *path = netdev_get_path(netdev);
+    device = NULL;
 #endif
 
 	switch (event) {
@@ -384,6 +381,7 @@ static void device_netdev_notify(struct netdev *netdev,
 		l_dbus_property_changed(dbus, path,
 					IWD_DEVICE_INTERFACE, "Powered");
 		break;
+#endif
 	case NETDEV_WATCH_EVENT_NAME_CHANGE:
 		l_dbus_property_changed(dbus, path,
 					IWD_DEVICE_INTERFACE, "Name");
@@ -392,7 +390,6 @@ static void device_netdev_notify(struct netdev *netdev,
 		l_dbus_property_changed(dbus, path,
 					IWD_DEVICE_INTERFACE, "Address");
 		break;
-#endif
 	default:
 		break;
 	}

--- a/src/device.c
+++ b/src/device.c
@@ -290,9 +290,7 @@ static void device_wiphy_state_changed_event(struct wiphy *wiphy,
 static struct device *device_create(struct wiphy *wiphy, struct netdev *netdev)
 {
 	struct device *device;
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 	uint32_t ifindex = netdev_get_ifindex(netdev);
 
 	device = l_new(struct device, 1);
@@ -300,11 +298,11 @@ static struct device *device_create(struct wiphy *wiphy, struct netdev *netdev)
 	device->wiphy = wiphy;
 	device->netdev = netdev;
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus, netdev_get_path(device->netdev),
 					IWD_DEVICE_INTERFACE, device))
 		l_info("Unable to register %s interface", IWD_DEVICE_INTERFACE);
 
+#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus, netdev_get_path(device->netdev),
 					L_DBUS_INTERFACE_PROPERTIES, device))
 		l_info("Unable to register %s interface",
@@ -351,14 +349,17 @@ static void device_netdev_notify(struct netdev *netdev,
 
 	if (!device && event != NETDEV_WATCH_EVENT_NEW)
 		return;
+#else
+    // TODO
+    struct device *device = NULL;
+    struct l_dbus *dbus = dbus_get_bus();
+    const char *path = netdev_get_path(netdev);
 #endif
 
 	switch (event) {
 	case NETDEV_WATCH_EVENT_NEW:
-#ifdef HAVE_DBUS
 		if (L_WARN_ON(device))
 			break;
-#endif
 
 		if (netdev_get_iftype(netdev) == NETDEV_IFTYPE_P2P_CLIENT ||
 				netdev_get_iftype(netdev) ==
@@ -367,10 +368,10 @@ static void device_netdev_notify(struct netdev *netdev,
 
 		device_create(netdev_get_wiphy(netdev), netdev);
 		break;
-#ifdef HAVE_DBUS
 	case NETDEV_WATCH_EVENT_DEL:
 		l_dbus_unregister_object(dbus, path);
 		break;
+#ifdef HAVE_DBUS
 	case NETDEV_WATCH_EVENT_UP:
 		device->powered = true;
 
@@ -406,13 +407,11 @@ static void destroy_device_interface(void *user_data)
 
 static int device_init(void)
 {
-#ifdef HAVE_DBUS
 	if (!l_dbus_register_interface(dbus_get_bus(),
 					IWD_DEVICE_INTERFACE,
 					setup_device_interface,
 					destroy_device_interface, false))
 		return -EPERM;
-#endif
 
 	netdev_watch = netdev_watch_add(device_netdev_notify, NULL, NULL);
 
@@ -422,9 +421,7 @@ static int device_init(void)
 static void device_exit(void)
 {
 	netdev_watch_remove(netdev_watch);
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_DEVICE_INTERFACE);
-#endif
 }
 
 IWD_MODULE(device, device_init, device_exit)

--- a/src/diagnostic.c
+++ b/src/diagnostic.c
@@ -26,8 +26,8 @@
 
 #include <ell/ell.h>
 
-#include "src/diagnostic.h"
 #include "src/dbus.h"
+#include "src/diagnostic.h"
 #include "src/ie.h"
 
 /*

--- a/src/dpp.c
+++ b/src/dpp.c
@@ -202,10 +202,14 @@ static bool dpp_get_uri(struct l_dbus *dbus,
 	l_dbus_message_builder_append_basic(builder, 's', dpp->uri);
 	return true;
 }
-
+#include <stdio.h>
 static void dpp_property_changed_notify(struct dpp_sm *dpp)
 {
 	const char *path = netdev_get_path(dpp->netdev);
+
+    printf("PATH: %s\n", path);
+
+    return;
 
 	l_dbus_property_changed(dbus_get_bus(), path, IWD_DPP_INTERFACE,
 				"Started");
@@ -2398,10 +2402,13 @@ static void dpp_create(struct netdev *netdev)
 				dpp_handle_config_request_frame, dpp, NULL);
 
 	l_queue_push_tail(dpp_list, dpp);
+
 }
 
+// FIND_FUNC(find_dpp, struct dpp_sm);
+
 static void dpp_netdev_watch(struct netdev *netdev,
-				enum netdev_watch_event event, void *userdata)
+enum netdev_watch_event event, void *userdata)
 {
 	switch (event) {
 	case NETDEV_WATCH_EVENT_NEW:
@@ -2412,6 +2419,8 @@ static void dpp_netdev_watch(struct netdev *netdev,
 		break;
 	case NETDEV_WATCH_EVENT_DEL:
 	case NETDEV_WATCH_EVENT_DOWN:
+		// FIND_AND_REMOVE(find_dpp, dpp_list, dpp_free);
+
 		l_dbus_object_remove_interface(dbus_get_bus(),
 						netdev_get_path(netdev),
 						IWD_DPP_INTERFACE);

--- a/src/dpp.c
+++ b/src/dpp.c
@@ -202,14 +202,10 @@ static bool dpp_get_uri(struct l_dbus *dbus,
 	l_dbus_message_builder_append_basic(builder, 's', dpp->uri);
 	return true;
 }
-#include <stdio.h>
+
 static void dpp_property_changed_notify(struct dpp_sm *dpp)
 {
 	const char *path = netdev_get_path(dpp->netdev);
-
-    printf("PATH: %s\n", path);
-
-    return;
 
 	l_dbus_property_changed(dbus_get_bus(), path, IWD_DPP_INTERFACE,
 				"Started");
@@ -2405,10 +2401,8 @@ static void dpp_create(struct netdev *netdev)
 
 }
 
-// FIND_FUNC(find_dpp, struct dpp_sm);
-
 static void dpp_netdev_watch(struct netdev *netdev,
-enum netdev_watch_event event, void *userdata)
+                               enum netdev_watch_event event, void *userdata)
 {
 	switch (event) {
 	case NETDEV_WATCH_EVENT_NEW:
@@ -2419,8 +2413,6 @@ enum netdev_watch_event event, void *userdata)
 		break;
 	case NETDEV_WATCH_EVENT_DEL:
 	case NETDEV_WATCH_EVENT_DOWN:
-		// FIND_AND_REMOVE(find_dpp, dpp_list, dpp_free);
-
 		l_dbus_object_remove_interface(dbus_get_bus(),
 						netdev_get_path(netdev),
 						IWD_DPP_INTERFACE);

--- a/src/iwd.h
+++ b/src/iwd.h
@@ -42,19 +42,3 @@ const char *iwd_get_iface_blacklist(void);
 const char *iwd_get_phy_whitelist(void);
 const char *iwd_get_phy_blacklist(void);
 bool iwd_is_developer_mode(void);
-
-#define FIND_FUNC(FUNC, T) \
-   bool FUNC(const void *obj_t, const void *netdev) { \
-       const T *obj = obj_t; \
-       return obj->netdev == netdev; \
-   }
-
-#define FIND_AND_REMOVE(FUNC, LIST, FREE_FUNC) \
-   do { \
-      void *obj = l_queue_find(LIST, &FUNC, netdev); \
-      if (obj) { \
-          l_queue_remove(LIST, obj); \
-          FREE_FUNC(obj); \
-      } \
-      return; \
-   } while(0)

--- a/src/iwd.h
+++ b/src/iwd.h
@@ -42,3 +42,19 @@ const char *iwd_get_iface_blacklist(void);
 const char *iwd_get_phy_whitelist(void);
 const char *iwd_get_phy_blacklist(void);
 bool iwd_is_developer_mode(void);
+
+#define FIND_FUNC(FUNC, T) \
+   bool FUNC(const void *obj_t, const void *netdev) { \
+       const T *obj = obj_t; \
+       return obj->netdev == netdev; \
+   }
+
+#define FIND_AND_REMOVE(FUNC, LIST, FREE_FUNC) \
+   do { \
+      void *obj = l_queue_find(LIST, &FUNC, netdev); \
+      if (obj) { \
+          l_queue_remove(LIST, obj); \
+          FREE_FUNC(obj); \
+      } \
+      return; \
+   } while(0)

--- a/src/knownnetworks.c
+++ b/src/knownnetworks.c
@@ -220,14 +220,16 @@ static void known_network_register_dbus(struct network_info *network)
 		l_info("Unable to register %s interface",
 						IWD_KNOWN_NETWORK_INTERFACE);
 
+#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus_get_bus(), path,
 					L_DBUS_INTERFACE_PROPERTIES, network))
 		l_info("Unable to register %s interface",
 						L_DBUS_INTERFACE_PROPERTIES);
+#endif
 }
 
 static void known_network_set_autoconnect(struct network_info *network,
-							bool autoconnect)
+bool autoconnect)
 {
 	if (network->config.is_autoconnectable == autoconnect)
 		return;

--- a/src/knownnetworks.c
+++ b/src/knownnetworks.c
@@ -236,10 +236,8 @@ bool autoconnect)
 
 	network->config.is_autoconnectable = autoconnect;
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus_get_bus(), known_network_get_path(network),
 				IWD_KNOWN_NETWORK_INTERFACE, "AutoConnect");
-#endif
 }
 
 static int known_network_touch(struct network_info *info)
@@ -439,12 +437,10 @@ void known_network_set_connected_time(struct network_info *network,
 
 	network->config.connected_time = connected_time;
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus_get_bus(),
 				known_network_get_path(network),
 				IWD_KNOWN_NETWORK_INTERFACE,
 				"LastConnectedTime");
-#endif
 
 	l_queue_remove(known_networks, network);
 	l_queue_insert(known_networks, network, connected_time_compare, NULL);
@@ -463,12 +459,10 @@ void known_network_update(struct network_info *network,
 		else if (!old->is_hidden && new->is_hidden)
 			num_known_hidden_networks++;
 
-#ifdef HAVE_DBUS
 		l_dbus_property_changed(dbus_get_bus(),
 					known_network_get_path(network),
 					IWD_KNOWN_NETWORK_INTERFACE,
 					"Hidden");
-#endif
 
 		old->is_hidden = new->is_hidden;
 	}
@@ -735,10 +729,8 @@ void known_networks_remove(struct network_info *network)
 		num_known_hidden_networks--;
 
 	l_queue_remove(known_networks, network);
-#ifdef HAVE_DBUS
 	l_dbus_unregister_object(dbus_get_bus(),
 					known_network_get_path(network));
-#endif
 
 	WATCHLIST_NOTIFY(&known_network_watches,
 				known_networks_watch_func_t,
@@ -758,9 +750,7 @@ void known_networks_remove(struct network_info *network)
 void known_networks_add(struct network_info *network)
 {
 	l_queue_insert(known_networks, network, connected_time_compare, NULL);
-#ifdef HAVE_DBUS
 	known_network_register_dbus(network);
-#endif
 
 	WATCHLIST_NOTIFY(&known_network_watches,
 				known_networks_watch_func_t,
@@ -1057,15 +1047,12 @@ void known_networks_watch_remove(uint32_t id)
 
 static int known_networks_init(void)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 	DIR *dir;
 	struct dirent *dirent;
 
 	L_AUTO_FREE_VAR(char *, storage_dir) = storage_get_path(NULL);
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_register_interface(dbus, IWD_KNOWN_NETWORK_INTERFACE,
 						setup_known_network_interface,
 						NULL, false)) {
@@ -1073,14 +1060,11 @@ static int known_networks_init(void)
 				IWD_KNOWN_NETWORK_INTERFACE);
 		return -EPERM;
 	}
-#endif
 
 	dir = opendir(storage_dir);
 	if (!dir) {
 		l_info("Unable to open %s: %s", storage_dir, strerror(errno));
-#ifdef HAVE_DBUS
 		l_dbus_unregister_interface(dbus, IWD_KNOWN_NETWORK_INTERFACE);
-#endif
 		return -ENOENT;
 	}
 
@@ -1131,18 +1115,14 @@ static int known_networks_init(void)
 
 static void known_networks_exit(void)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 
 	l_dir_watch_destroy(storage_dir_watch);
 
 	l_queue_destroy(known_networks, network_info_free);
 	known_networks = NULL;
 
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus, IWD_KNOWN_NETWORK_INTERFACE);
-#endif
 
 	watchlist_destroy(&known_network_watches);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,7 @@
 
 #include "linux/nl80211.h"
 
+#include "src/agent.h"
 #include "src/iwd.h"
 #include "src/module.h"
 #include "src/wiphy.h"
@@ -85,6 +86,8 @@ static void iwd_shutdown(void)
 
 #ifdef HAVE_DBUS
 	dbus_shutdown();
+#else
+    agent_shutdown();
 #endif
 	netdev_shutdown();
 

--- a/src/main.c
+++ b/src/main.c
@@ -84,11 +84,8 @@ static void iwd_shutdown(void)
 		return;
 	}
 
-#ifdef HAVE_DBUS
 	dbus_shutdown();
-#else
-    agent_shutdown();
-#endif
+
 	netdev_shutdown();
 
 	timeout = l_timeout_create(1, main_loop_quit, NULL, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -39,11 +39,11 @@
 
 #include "linux/nl80211.h"
 
+#include "src/dbus.h"
 #include "src/agent.h"
 #include "src/iwd.h"
 #include "src/module.h"
 #include "src/wiphy.h"
-#include "src/dbus.h"
 #include "src/eap.h"
 #include "src/eapol.h"
 #include "src/rfkill.h"

--- a/src/netconfig.c
+++ b/src/netconfig.c
@@ -41,6 +41,7 @@
 #include "src/iwd.h"
 #include "src/module.h"
 #include "src/netdev.h"
+#include "src/dbus.h"
 #include "src/station.h"
 #include "src/common.h"
 #include "src/network.h"

--- a/src/netdev.c
+++ b/src/netdev.c
@@ -63,6 +63,7 @@
 #include "src/fils.h"
 #include "src/auth-proto.h"
 #include "src/frame-xchg.h"
+#include "src/dbus.h"
 #include "src/diagnostic.h"
 #include "src/band.h"
 

--- a/src/network.c
+++ b/src/network.c
@@ -764,10 +764,8 @@ void network_set_info(struct network *network, struct network_info *info)
 		network->info = NULL;
 	}
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus_get_bus(), network_get_path(network),
 					IWD_NETWORK_INTERFACE, "KnownNetwork");
-#endif
 }
 
 void network_set_force_default_owe_group(struct network *network)
@@ -1795,7 +1793,6 @@ static bool network_property_get_known_network(struct l_dbus *dbus,
 
 bool network_register(struct network *network, const char *path)
 {
-#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus_get_bus(), path,
 					IWD_NETWORK_INTERFACE, network)) {
 		l_info("Unable to register %s interface",
@@ -1803,6 +1800,7 @@ bool network_register(struct network *network, const char *path)
 		return false;
 	}
 
+#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus_get_bus(), path,
 					L_DBUS_INTERFACE_PROPERTIES, network))
 		l_info("Unable to register %s interface",
@@ -1816,9 +1814,7 @@ bool network_register(struct network *network, const char *path)
 
 static void network_unregister(struct network *network, int reason)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 
 	if (network->connect_after_anqp)
 		dbus_pending_reply(&network->connect_after_anqp,
@@ -1831,9 +1827,7 @@ static void network_unregister(struct network *network, int reason)
 	agent_request_cancel(network->agent_request, reason);
 	network_settings_close(network);
 
-#ifdef HAVE_DBUS
 	l_dbus_unregister_object(dbus, network->object_path);
-#endif
 
 	l_free(network->object_path);
 	network->object_path = NULL;
@@ -2101,12 +2095,10 @@ static void setup_network_interface(struct l_dbus_interface *interface)
 
 static int network_init(void)
 {
-#ifdef HAVE_DBUS
 	if (!l_dbus_register_interface(dbus_get_bus(), IWD_NETWORK_INTERFACE,
 					setup_network_interface, NULL, false))
 		l_error("Unable to register %s interface",
 						IWD_NETWORK_INTERFACE);
-#endif
 
 	known_networks_watch =
 		known_networks_watch_add(known_networks_changed, NULL, NULL);
@@ -2124,9 +2116,7 @@ static void network_exit(void)
 	station_remove_event_watch(event_watch);
 	event_watch = 0;
 
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_NETWORK_INTERFACE);
-#endif
 }
 
 IWD_MODULE(network, network_init, network_exit)

--- a/src/ofono.c
+++ b/src/ofono.c
@@ -30,7 +30,6 @@
 #include <errno.h>
 
 #include <ell/ell.h>
-#include <ell/dbus.h>
 
 #include "src/dbus.h"
 #include "src/simauth.h"

--- a/src/p2p.c
+++ b/src/p2p.c
@@ -3584,6 +3584,7 @@ static bool p2p_device_peer_add(struct p2p_device *dev, struct p2p_peer *peer)
 		return false;
 	}
 
+#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus_get_bus(),
 						p2p_peer_get_path(peer),
 						L_DBUS_INTERFACE_PROPERTIES,
@@ -3594,6 +3595,7 @@ static bool p2p_device_peer_add(struct p2p_device *dev, struct p2p_peer *peer)
 			L_DBUS_INTERFACE_PROPERTIES, p2p_peer_get_path(peer));
 		return false;
 	}
+#endif
 
 	peer->wsc.get_path = p2p_peer_wsc_get_path;
 	peer->wsc.connect = p2p_peer_wsc_connect;

--- a/src/p2p.c
+++ b/src/p2p.c
@@ -274,9 +274,7 @@ static void p2p_peer_put(void *user_data)
 	 * Removes all interfaces with one call, no need to call
 	 * wsc_dbus_remove_interface.
 	 */
-#ifdef HAVE_DBUS
 	l_dbus_unregister_object(dbus_get_bus(), p2p_peer_get_path(peer));
-#endif
 	p2p_peer_free(peer);
 }
 
@@ -4439,13 +4437,11 @@ struct p2p_device *p2p_device_update_from_genl(struct l_genl_msg *msg,
 					p2p_mlme_notify, dev, NULL))
 		l_error("Registering for MLME notifications failed");
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus_get_bus(),
 						p2p_device_get_path(dev),
 						IWD_P2P_INTERFACE, dev))
 		l_info("Unable to add the %s interface to %s",
 			IWD_P2P_INTERFACE, p2p_device_get_path(dev));
-#endif
 
 	return dev;
 }
@@ -4468,9 +4464,7 @@ static void p2p_device_free(void *user_data)
 
 	p2p_device_discovery_stop(dev);
 	p2p_connection_reset(dev);
-#ifdef HAVE_DBUS
 	l_dbus_unregister_object(dbus_get_bus(), p2p_device_get_path(dev));
-#endif
 	l_queue_destroy(dev->peer_list, p2p_peer_put);
 	l_queue_destroy(dev->discovery_users, p2p_discovery_user_free);
 	l_genl_family_free(dev->nl80211); /* Cancels dev->start_stop_cmd_id */
@@ -5156,7 +5150,6 @@ static void p2p_service_manager_destroy_cb(void *user_data)
 
 static int p2p_init(void)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
 
 	if (!l_dbus_register_interface(dbus, IWD_P2P_INTERFACE,
@@ -5170,12 +5163,10 @@ static int p2p_init(void)
 					NULL, false))
 		l_error("Unable to register the %s interface",
 			IWD_P2P_PEER_INTERFACE);
-#endif
 
 	p2p_dhcp_settings = l_settings_new();
 	p2p_device_list = l_queue_new();
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_register_interface(dbus, IWD_P2P_WFD_INTERFACE,
 					p2p_wfd_interface_setup,
 					NULL, false))
@@ -5192,7 +5183,6 @@ static int p2p_init(void)
 					IWD_P2P_SERVICE_MANAGER_INTERFACE,
 					NULL))
 		l_error("Unable to register the P2P Service Manager object");
-#endif
 
 	if (!l_settings_get_uint(iwd_get_config(), "P2P", "DHCPTimeout",
 					&p2p_dhcp_timeout_val))
@@ -5203,14 +5193,12 @@ static int p2p_init(void)
 
 static void p2p_exit(void)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
 
 	l_dbus_unregister_interface(dbus, IWD_P2P_INTERFACE);
 	l_dbus_unregister_interface(dbus, IWD_P2P_PEER_INTERFACE);
 	l_dbus_unregister_interface(dbus, IWD_P2P_WFD_INTERFACE);
 	l_dbus_unregister_interface(dbus, IWD_P2P_SERVICE_MANAGER_INTERFACE);
-#endif
 	l_queue_destroy(p2p_device_list, p2p_device_free);
 	p2p_device_list = NULL;
 	l_settings_free(p2p_dhcp_settings);

--- a/src/rrm.c
+++ b/src/rrm.c
@@ -36,6 +36,7 @@
 #include "src/iwd.h"
 #include "src/ie.h"
 #include "src/util.h"
+#include "src/dbus.h"
 #include "src/station.h"
 #include "src/scan.h"
 #include "src/nl80211util.h"

--- a/src/station.c
+++ b/src/station.c
@@ -5068,8 +5068,6 @@ static void add_frame_watches(struct netdev *netdev)
 			L_UINT_TO_PTR(netdev_get_ifindex(netdev)), NULL);
 }
 
-// FIND_FUNC(find_station, struct station);
-
 static void station_netdev_watch(struct netdev *netdev,
 				enum netdev_watch_event event, void *userdata)
 {
@@ -5089,8 +5087,6 @@ static void station_netdev_watch(struct netdev *netdev,
 		break;
 	case NETDEV_WATCH_EVENT_DOWN:
 	case NETDEV_WATCH_EVENT_DEL:
-    	// FIND_AND_REMOVE(find_station, station_list, station_free);
-
 		l_dbus_object_remove_interface(dbus_get_bus(),
 						netdev_get_path(netdev),
 						IWD_STATION_INTERFACE);

--- a/src/station.c
+++ b/src/station.c
@@ -232,11 +232,9 @@ static void station_property_set_scanning(struct station *station,
 
 	station->scanning = scanning;
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus_get_bus(),
 				netdev_get_path(station->netdev),
 					IWD_STATION_INTERFACE, "Scanning");
-#endif
 }
 
 static void station_enter_state(struct station *station,
@@ -1526,9 +1524,7 @@ static void station_enter_state(struct station *station,
 						enum station_state state)
 {
 	uint64_t id = netdev_get_wdev_id(station->netdev);
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 	bool disconnected;
 	int ret;
 
@@ -1536,14 +1532,12 @@ static void station_enter_state(struct station *station,
 			station_state_to_string(station->state),
 			station_state_to_string(state));
 
-#ifdef HAVE_DBUS
 	disconnected = !station_is_busy(station);
 
 	if ((disconnected && state > STATION_STATE_AUTOCONNECT_FULL) ||
 			(!disconnected && state != station->state))
 		l_dbus_property_changed(dbus, netdev_get_path(station->netdev),
 					IWD_STATION_INTERFACE, "State");
-#endif
 
 	station->state = state;
 
@@ -1569,13 +1563,11 @@ static void station_enter_state(struct station *station,
 					station->connected_network,
 					network_rank_compare, NULL);
 
-#ifdef HAVE_DBUS
 		l_dbus_property_changed(dbus, netdev_get_path(station->netdev),
 				IWD_STATION_INTERFACE, "ConnectedNetwork");
 		l_dbus_property_changed(dbus,
 				network_get_path(station->connected_network),
 				IWD_NETWORK_INTERFACE, "Connected");
-#endif
 
 		if (station->signal_agent)
 			station_signal_agent_notify(station);
@@ -1583,12 +1575,10 @@ static void station_enter_state(struct station *station,
 		periodic_scan_stop(station);
 		break;
 	case STATION_STATE_CONNECTED:
-#ifdef HAVE_DBUS
 		l_dbus_object_add_interface(dbus,
 					netdev_get_path(station->netdev),
 					IWD_STATION_DIAGNOSTIC_INTERFACE,
 					station);
-#endif
 		periodic_scan_stop(station);
 
 		station_set_evict_nocarrier(station, true);
@@ -1713,9 +1703,7 @@ static void station_roam_state_clear(struct station *station)
 static void station_reset_connection_state(struct station *station)
 {
 	struct network *network = station->connected_network;
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 
 	l_debug("%u", netdev_get_ifindex(station->netdev));
 
@@ -1736,14 +1724,12 @@ static void station_reset_connection_state(struct station *station)
 	station->connected_bss = NULL;
 	station->connected_network = NULL;
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus, netdev_get_path(station->netdev),
 				IWD_STATION_INTERFACE, "ConnectedNetwork");
 	l_dbus_property_changed(dbus, network_get_path(network),
 				IWD_NETWORK_INTERFACE, "Connected");
 	l_dbus_object_remove_interface(dbus, netdev_get_path(station->netdev),
 				IWD_STATION_DIAGNOSTIC_INTERFACE);
-#endif
 
 	/*
 	 * Perform this step last since calling network_disconnected() might
@@ -4385,7 +4371,6 @@ static void station_free(struct station *station)
 	if (!l_queue_remove(station_list, station))
 		return;
 
-#ifdef HAVE_DBUS
 	l_dbus_object_remove_interface(dbus_get_bus(),
 					netdev_get_path(station->netdev),
 					IWD_STATION_DIAGNOSTIC_INTERFACE);
@@ -4393,7 +4378,6 @@ static void station_free(struct station *station)
 		l_dbus_object_remove_interface(dbus_get_bus(),
 					netdev_get_path(station->netdev),
 					IWD_STATION_DEBUG_INTERFACE);
-#endif
 
 	if (station->netconfig) {
 		netconfig_destroy(station->netconfig);
@@ -5144,7 +5128,6 @@ static int station_init(void)
 	l_dbus_register_interface(dbus_get_bus(), IWD_STATION_INTERFACE,
 					station_setup_interface,
 					station_destroy_interface, false);
-#ifdef HAVE_DBUS
 	l_dbus_register_interface(dbus_get_bus(),
 					IWD_STATION_DIAGNOSTIC_INTERFACE,
 					station_setup_diagnostic_interface,
@@ -5156,7 +5139,6 @@ static int station_init(void)
 					station_setup_debug_interface,
 					NULL,
 					false);
-#endif
 
 	if (!l_settings_get_uint(iwd_get_config(), "General",
 					"ManagementFrameProtection",
@@ -5202,13 +5184,11 @@ static int station_init(void)
 
 static void station_exit(void)
 {
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(),
 					IWD_STATION_DIAGNOSTIC_INTERFACE);
 	if (iwd_is_developer_mode())
 		l_dbus_unregister_interface(dbus_get_bus(),
 					IWD_STATION_DEBUG_INTERFACE);
-#endif
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_STATION_INTERFACE);
 	netdev_watch_remove(netdev_watch);
 	l_queue_destroy(station_list, NULL);

--- a/src/wiphy.c
+++ b/src/wiphy.c
@@ -1972,9 +1972,7 @@ static int wiphy_get_permanent_addr_from_sysfs(struct wiphy *wiphy)
 
 static void wiphy_register(struct wiphy *wiphy)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 
 	wiphy->soft_rfkill = rfkill_get_soft_state(wiphy->id);
 	wiphy->hard_rfkill = rfkill_get_hard_state(wiphy->id);
@@ -2014,12 +2012,12 @@ static void wiphy_register(struct wiphy *wiphy)
 
 	wiphy_get_driver_name(wiphy);
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus, wiphy_get_path(wiphy),
 					IWD_WIPHY_INTERFACE, wiphy))
 		l_info("Unable to add the %s interface to %s",
 				IWD_WIPHY_INTERFACE, wiphy_get_path(wiphy));
 
+#ifdef HAVE_DBUS
 	if (!l_dbus_object_add_interface(dbus, wiphy_get_path(wiphy),
 					L_DBUS_INTERFACE_PROPERTIES, NULL))
 		l_info("Unable to add the %s interface to %s",
@@ -2065,14 +2063,12 @@ void wiphy_update_name(struct wiphy *wiphy, const char *name)
 		updated = true;
 	}
 
-#ifdef HAVE_DBUS
 	if (updated && wiphy->registered) {
 		struct l_dbus *dbus = dbus_get_bus();
 
 		l_dbus_property_changed(dbus, wiphy_get_path(wiphy),
 					IWD_WIPHY_INTERFACE, "Name");
 	}
-#endif
 }
 
 static void wiphy_set_station_capability_bits(struct wiphy *wiphy)
@@ -2424,10 +2420,8 @@ bool wiphy_destroy(struct wiphy *wiphy)
 	if (!l_queue_remove(wiphy_list, wiphy))
 		return false;
 
-#ifdef HAVE_DBUS
 	if (wiphy->registered)
 		l_dbus_unregister_object(dbus_get_bus(), wiphy_get_path(wiphy));
-#endif
 
 	wiphy_free(wiphy);
 	return true;
@@ -2437,9 +2431,7 @@ static void wiphy_rfkill_cb(unsigned int wiphy_id, bool soft, bool hard,
 				void *user_data)
 {
 	struct wiphy *wiphy = wiphy_find(wiphy_id);
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
-#endif
 	bool old_powered, new_powered;
 	enum wiphy_state_watch_event event;
 
@@ -2461,10 +2453,8 @@ static void wiphy_rfkill_cb(unsigned int wiphy_id, bool soft, bool hard,
 	WATCHLIST_NOTIFY(&wiphy->state_watches, wiphy_state_watch_func_t,
 				wiphy, event);
 
-#ifdef HAVE_DBUS
 	l_dbus_property_changed(dbus, wiphy_get_path(wiphy),
 					IWD_WIPHY_INTERFACE, "Powered");
-#endif
 }
 
 static bool wiphy_property_get_powered(struct l_dbus *dbus,
@@ -2805,14 +2795,12 @@ static int wiphy_init(void)
 
 	rfkill_watch_add(wiphy_rfkill_cb, NULL);
 
-#ifdef HAVE_DBUS
 	if (!l_dbus_register_interface(dbus_get_bus(),
 					IWD_WIPHY_INTERFACE,
 					setup_wiphy_interface,
 					NULL, false))
 		l_error("Unable to register the %s interface",
 				IWD_WIPHY_INTERFACE);
-#endif
 
 	hwdb = l_hwdb_new_default();
 
@@ -2858,9 +2846,7 @@ static void wiphy_exit(void)
 	nl80211 = NULL;
 	mac_randomize_bytes = 6;
 
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_WIPHY_INTERFACE);
-#endif
 
 	l_hwdb_unref(hwdb);
 }

--- a/src/wsc.c
+++ b/src/wsc.c
@@ -1221,7 +1221,6 @@ static void setup_wsc_interface(struct l_dbus_interface *interface)
 
 bool wsc_dbus_add_interface(struct wsc_dbus *wsc)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
 
 	if (!l_dbus_object_add_interface(dbus, wsc->get_path(wsc),
@@ -1229,19 +1228,16 @@ bool wsc_dbus_add_interface(struct wsc_dbus *wsc)
 		l_info("Unable to register %s interface", IWD_WSC_INTERFACE);
 		return false;
 	}
-#endif
 
 	return true;
 }
 
 void wsc_dbus_remove_interface(struct wsc_dbus *wsc)
 {
-#ifdef HAVE_DBUS
 	struct l_dbus *dbus = dbus_get_bus();
 
 	l_dbus_object_remove_interface(dbus, wsc->get_path(wsc),
 					IWD_WSC_INTERFACE);
-#endif
 }
 
 static void wsc_dbus_free(void *user_data)
@@ -1294,7 +1290,6 @@ static void wsc_netdev_watch(struct netdev *netdev,
 {
 	switch (event) {
 	case NETDEV_WATCH_EVENT_UP:
-#ifdef HAVE_DBUS
 	case NETDEV_WATCH_EVENT_NEW:
 		if (netdev_get_iftype(netdev) == NETDEV_IFTYPE_STATION &&
 				netdev_get_is_up(netdev))
@@ -1304,7 +1299,6 @@ static void wsc_netdev_watch(struct netdev *netdev,
 	case NETDEV_WATCH_EVENT_DEL:
 		wsc_remove_station(netdev);
 		break;
-#endif
 	default:
 		break;
 	}
@@ -1314,20 +1308,16 @@ static int wsc_init(void)
 {
 	l_debug("");
 	netdev_watch = netdev_watch_add(wsc_netdev_watch, NULL, NULL);
-#ifdef HAVE_DBUS
 	l_dbus_register_interface(dbus_get_bus(), IWD_WSC_INTERFACE,
 					setup_wsc_interface,
 					wsc_dbus_free, false);
-#endif
 	return 0;
 }
 
 static void wsc_exit(void)
 {
 	l_debug("");
-#ifdef HAVE_DBUS
 	l_dbus_unregister_interface(dbus_get_bus(), IWD_WSC_INTERFACE);
-#endif
 	netdev_watch_remove(netdev_watch);
 }
 


### PR DESCRIPTION
A lot of the stubbed out DBUS calls are actually responsible for correlating a `netdev` with allocated resources and `free`-ing them, for example, take `dpp.c`

- A DBUS interface is registered https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L2735

- The setup function is mundane https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L2698

- But the destructor does a very important task of removing the pointer from the queue and free-ing it https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L2716 (constructed here https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L2386)

- This leads to a use after free because when a `netdev` is free-d, it would trigger the watcher, causing the respective `dpp` to get free'd and removed from the queue before `free` is actually called on the `netdev` https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L2415

- However, if dbus is not present, this never happens and when the `dpp` list is cleared at the end, the `dpp` object obviously references a stray `netdev` which is used here https://github.com/illiliti/eiwd/blob/master/src/dpp.c#L208

- Similar cases were present in almost all the other files, causing leaks

So for this we basically have to emulate what DBus does, which is being done in `dbus-stub.c`, just a garbage example, it needs to be re written to use `l_hashmap`

Most of the other function calls like `l_dbus_interface_property` are useless and just return failure

Also this change must be made to the `ell` submodule so that our `dbus.h` hacks can take precedence

```diff
diff --git a/ell/ell.h b/ell/ell.h
index 647f411..7ca19ce 100644
--- a/ell/ell.h
+++ b/ell/ell.h
@@ -51,9 +51,6 @@
 #include <ell/netlink.h>
 #include <ell/genl.h>
 #include <ell/rtnl.h>
-#include <ell/dbus.h>
-#include <ell/dbus-service.h>
-#include <ell/dbus-client.h>
 #include <ell/dhcp.h>
 #include <ell/dhcp6.h>
 #include <ell/icmp6.h>
```